### PR TITLE
fixed +/- 0.0* returning undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var ZTABLE =
 {
-    'z': [0.09, 0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0.0],
+    'z': [0.09, 0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0],
     '-3.4': [ 0.0002, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003],
     '-3.3': [ 0.0003, 0.0004, 0.0004, 0.0004, 0.0004, 0.0004, 0.0004, 0.0005, 0.0005, 0.0005],
     '-3.2': [ 0.0005, 0.0005, 0.0005, 0.0006, 0.0006, 0.0006, 0.0006, 0.0006, 0.0007, 0.0007],
@@ -70,8 +70,10 @@ module.exports = function (zscore) {
     }
     xZscore = Math.abs(Math.round((zscore % yZscore) * 10000) / 10000);
 
-    var col = ZTABLE.z.indexOf(xZscore);
-    var perc = ZTABLE[yZscore.toFixed(1)][col];
+    var z100 = isNaN(xZscore) ? Math.abs(zscore) : xZscore;
+    var z10 = yZscore === 0 ? '0.0' : yZscore.toFixed(1);
+    var col = ZTABLE.z.indexOf(z100);
+    var perc = ZTABLE[z10][col];
 
     if(zscore > 0) {
         perc = Math.round((1 - perc) * 10000) / 10000;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "ztable",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Convert z-scores to a percentiles.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha ./test/*",
-    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -R --spec"
+    "test": "node ./node_modules/mocha/bin/mocha ./test/*",
+    "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -R --spec"
   },
   "repository": {
     "type": "git",
@@ -16,6 +16,10 @@
     {
       "name": "Arjan Frans",
       "email": "arjanfrans.com@gmail.com"
+    },
+    {
+      "name": "Ryan Willis",
+      "email": "icodeninja@gmail.com"
     }
   ],
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,8 @@ describe('ztable', function () {
         this.v8 = ztable(1.1097576707798367);
         this.v9 = ztable(1.109733243278343243243214353453425454325);
         this.v10 = ztable(1);
+        this.v11 = ztable(-0.03);
+        this.v12 = ztable(0.03);
     });
 
     it('zscores match percentiles', function () {
@@ -26,7 +28,8 @@ describe('ztable', function () {
         expect(this.v8).to.equal(0.8643);
         expect(this.v9).to.equal(0.8643);
         expect(this.v10).to.equal(0.8413);
-
+        expect(this.v11).to.equal(0.4880);
+        expect(this.v12).to.equal(0.5120);
         this.stringInput = ztable('2');
         expect(this.stringInput).to.equal(0.9772);
     });


### PR DESCRIPTION
Hey, nice tool! However, during implementation, I found that any values given to the function under 0.1 were showing up as undefined, so I cloned the repo and added it to the tests and sure enough, they failed.

I'm submitting this patch because it the function will fail for all numbers positive or negative like this: 0.0*.

Thanks!
